### PR TITLE
Update dbo.sp_VLFCount.sql

### DIFF
--- a/utils/dbo.sp_VLFCount.sql
+++ b/utils/dbo.sp_VLFCount.sql
@@ -31,7 +31,7 @@ CREATE TABLE #Loginfo
 			( 
 			  RecoveryUnitId INT 
 			 ,FileID TINYINT 
-			 ,FileSize INT 
+			 ,FileSize BIGINT 
 			 ,StartOffset BIGINT 
 			 ,FSeqNo INT 
 			 ,[Status] TINYINT


### PR DESCRIPTION
#Loginfo.FileSize widened to BIGINT to prevent error 8114 (Error converting data type bigint to int)